### PR TITLE
Fix highlight CSS path

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -9,7 +9,7 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <link rel="stylesheet" href="libraries/frameworks/revealjs/css/reveal.min.css">
   <link rel="stylesheet" href="libraries/frameworks/revealjs/css/theme/default.css" id="theme">
-  <link rel="stylesheet" href="libraries/highlighters/highlight.js/css/.css" id="theme">
+  <link rel="stylesheet" href="libraries/highlighters/highlight.js/css/default.css" id="theme">
   <!--[if lt IE 9]>
   <script src="lib/js/html5shiv.js"></script>
   <![endif]-->  <link rel="stylesheet" href = "assets/css/ribbons.css">

--- a/Index.md
+++ b/Index.md
@@ -5,7 +5,7 @@ author      :
 job         : 
 framework   : revealjs      # {io2012, html5slides, shower, dzslides, ...}
 highlighter : highlight.js  # {highlight.js, prettify, highlight}
-hitheme     :               # 
+hitheme     : default       # highlight style
 widgets     : []            # {mathjax, quiz, bootstrap}
 mode        : selfcontained # {standalone, draft}
 knit        : slidify::knit2slides

--- a/index.Rmd
+++ b/index.Rmd
@@ -5,7 +5,7 @@ author      :
 job         : 
 framework   : revealjs      # {io2012, html5slides, shower, dzslides, ...}
 highlighter : highlight.js  # {highlight.js, prettify, highlight}
-hitheme     :               # 
+hitheme     : default       # highlight style
 widgets     : []            # {mathjax, quiz, bootstrap}
 mode        : selfcontained # {standalone, draft}
 knit        : slidify::knit2slides


### PR DESCRIPTION
## Summary
- ensure a highlight.js CSS theme is selected
- fix generated `Index.html` to include the default highlight stylesheet

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fc30e3e808332a31cda85fbef78c1